### PR TITLE
README.md - fix git clone link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Web pages also contain links. This plugin's `html_link` table queries for them.
 Install go, then:
 
 ```
-$ git clone https://github.com/judell/steampipe-plugin-html
+$ git clone https://github.com/turbot/steampipe-plugin-html
 
 $ cp ./config/html.spc ~/.steampipe/config
 


### PR DESCRIPTION
The git clone link was to the original judell/steampipe-plugin-html repo which no longer exists.